### PR TITLE
Fix https check

### DIFF
--- a/common.php
+++ b/common.php
@@ -224,7 +224,7 @@ class AutoNotify {
     // Now that we're not storing the DET in the query string - this simply needs to be the url to this plugin
     public function getDetUrl() {
         // Build the url of the page that called us
-        $isHttps = isset($_SERVER['HTTPS']) AND !empty($_SERVER['HTTPS']) AND $_SERVER['HTTPS'] != 'off';
+        $isHttps = true;
 
         // Force http for certain domains
         global $http_only;


### PR DESCRIPTION
Because the check for HTTPS uses `$_SERVER` values to whether ascertain the server is behind HTTPS
this breaks in situations where SSL is terminated at a proxy rather than on the server which
results with a conflict between the configured DET URL and the detected URL.

Since there is a global whitelist of http domains the default should be to assume the server
uses HTTPS rather than detecting it and rely on the `http_only` global for other domains.